### PR TITLE
Escaping input to prevent issues with special characters

### DIFF
--- a/splashtag.rb
+++ b/splashtag.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 module Jekyll
   class SplashTag < Liquid::Block
 
@@ -7,8 +9,9 @@ module Jekyll
 
     def render(context)
         input = super.to_s.gsub(%r{\A(\n|\r)+|(\n|\r)+\z}, "")
-        code = `SplashHTMLGen '#{input}'`
-        output = "<pre><code>#{code}</code></pre>"
+        command = Shellwords.join(['SplashHTMLGen', input])
+        code = `#{command}`
+        output = "<pre class=\"splash\"><code>#{code}</code></pre>"
     end
   end
 end


### PR DESCRIPTION
I was getting some errors when the code contained some characters such as `!`, this uses `Shellwords` to escape the input and prevent that issue.